### PR TITLE
Modified renderJournalSheet to not require the sheet to have a `document` member

### DIFF
--- a/module/logic.js
+++ b/module/logic.js
@@ -410,7 +410,7 @@ export class Polyglot {
 	 */
 	renderJournalSheet(journalSheet, html) {
 		this._addPolyglotEditor(journalSheet);
-		if (journalSheet.document.isOwner || game.user.isGM) {
+		if (journalSheet.document?.isOwner || game.user.isGM) {
 			let runes = false;
 			const texts = [];
 			const styles = [];


### PR DESCRIPTION
I've been locally adding support for Polyglot to other modules where it makes sense (such as Forien's Quest Log).

In my testing I found that most other modules "just work" using the `renderJournalSheet` method with no other modifications than not assuming its a journal sheet for the `document` member.

The Polyglot module is obviously not _designed_ to work as such but this change allows lots of modules sheets to support Polyglot simply using:
```
      // Support for Polyglot
      const polyglot = game.modules.get('polyglot');
      if (polyglot?.active && game.polyglot)
      {
         Hooks.on("render[YourSheetName]", game.polyglot.renderJournalSheet.bind(game.polyglot));
      }
```