### PR TITLE
Remove button class from 'globe' icon

### DIFF
--- a/src/module/hooks.js
+++ b/src/module/hooks.js
@@ -164,7 +164,7 @@ export default class PolyglotHooks {
 					? `data-tooltip="${language}" data-tooltip-direction="LEFT"`
 					: "";
 			const clickable = isGM && (runifyGM || !displayTranslated);
-			const button = $(`<a class="button polyglot-message-language ${clickable ? "" : "unclickable"}" ${title}>
+			const button = $(`<a class="polyglot-message-language ${clickable ? "" : "unclickable"}" ${title}>
 				<i class="fas fa-globe" style="color:${color}"></i>
 			</a>`);
 			metadata.find(".polyglot-message-language").remove();


### PR DESCRIPTION
Hi, I'm doing an UI thing and `a.button` causes things to be restyled as actual buttons.
Every other clickable element in the message header is just an `a`, with Polyglot being the exception.

I checked the Polyglot stylesheet, and the css doesn't use the button class for anything.