### PR TITLE
Support FoundryVTT v12

### DIFF
--- a/src/module/forms/FontSettings.js
+++ b/src/module/forms/FontSettings.js
@@ -7,7 +7,7 @@ export class PolyglotFontSettings extends FormApplication {
 		if (game.system.id === "wfrp4e") {
 			classes.push(game.system.id);
 		}
-		return mergeObject(super.defaultOptions, {
+		return foundry.utils.mergeObject(super.defaultOptions, {
 			id: "polyglot-font-form",
 			title: "Polyglot Font Settings",
 			template: "./modules/polyglot/templates/FontSettings.hbs",

--- a/src/module/forms/GeneralSettings.js
+++ b/src/module/forms/GeneralSettings.js
@@ -4,7 +4,7 @@ export class PolyglotGeneralSettings extends FormApplication {
 		if (game.system.id === "wfrp4e") {
 			classes.push(game.system.id);
 		}
-		return mergeObject(super.defaultOptions, {
+		return foundry.utils.mergeObject(super.defaultOptions, {
 			id: "polyglot-general-form",
 			title: "Polyglot General Settings",
 			template: "./modules/polyglot/templates/GeneralSettings.hbs",

--- a/src/module/forms/LanguageSettings.js
+++ b/src/module/forms/LanguageSettings.js
@@ -7,7 +7,7 @@ export class PolyglotLanguageSettings extends FormApplication {
 		if (game.system.id === "wfrp4e") {
 			classes.push(game.system.id);
 		}
-		return mergeObject(super.defaultOptions, {
+		return foundry.utils.mergeObject(super.defaultOptions, {
 			id: "polyglot-language-form",
 			title: "Polyglot Language Settings",
 			template: "./modules/polyglot/templates/LanguageSettings.hbs",

--- a/src/module/hooks.js
+++ b/src/module/hooks.js
@@ -72,8 +72,8 @@ export default class PolyglotHooks {
 			|| ["description", "narration", "notification"].includes(message.flags?.["narrator-tools"]?.type);
 		if (!isCheckboxEnabled || isMessageLink || isMessageInlineRoll || isDescMessage) return true;
 		if (
-			data.type === CONST.CHAT_MESSAGE_TYPES.IC
-			|| (game.polyglot._allowOOC() && game.polyglot._isMessageTypeOOC(data.type))
+			message.style === CONST.CHAT_MESSAGE_STYLES.IC
+			|| (game.polyglot._allowOOC() && game.polyglot._isMessageTypeOOC(message.style))
 		) {
 			let lang = game.polyglot.chatElement.find("select[name=polyglot-language]").val();
 			const language = data.lang || data.language;
@@ -192,7 +192,7 @@ export default class PolyglotHooks {
 	static createChatMessage(message, options, userId) {
 		if (
 			game.polyglot._isMessageLink(message.content)
-			|| (message.type === CONST.CHAT_MESSAGE_TYPES.OOC && !game.polyglot._allowOOC())
+			|| (message.style === CONST.CHAT_MESSAGE_STYLES.OOC && !game.polyglot._allowOOC())
 		) return false;
 	}
 

--- a/src/module/hooks.js
+++ b/src/module/hooks.js
@@ -73,7 +73,7 @@ export default class PolyglotHooks {
 		if (!isCheckboxEnabled || isMessageLink || isMessageInlineRoll || isDescMessage) return true;
 		if (
 			message.style === CONST.CHAT_MESSAGE_STYLES.IC
-			|| (game.polyglot._allowOOC() && game.polyglot._isMessageTypeOOC(message.style))
+			|| (message.style === CONST.CHAT_MESSAGE_STYLES.OOC && game.polyglot._allowOOC())
 		) {
 			let lang = game.polyglot.chatElement.find("select[name=polyglot-language]").val();
 			const language = data.lang || data.language;

--- a/src/module/hooks.js
+++ b/src/module/hooks.js
@@ -190,10 +190,8 @@ export default class PolyglotHooks {
 	 * @returns {Boolean}
 	 */
 	static createChatMessage(message, options, userId) {
-		if (
-			game.polyglot._isMessageLink(message.content)
-			|| (message.style === CONST.CHAT_MESSAGE_STYLES.OOC && !game.polyglot._allowOOC())
-		) return false;
+		return !(game.polyglot._isMessageLink(message.content)
+			|| (message.style === CONST.CHAT_MESSAGE_STYLES.OOC && !game.polyglot._allowOOC()));
 	}
 
 	/**

--- a/src/module/logic.js
+++ b/src/module/logic.js
@@ -375,7 +375,7 @@ export class Polyglot {
 		}
 
 		const salted_string = string + salt;
-		const seed = new MersenneTwister(this._hashCode(salted_string));
+		const seed = new foundry.dice.MersenneTwister(this._hashCode(salted_string));
 		const regex = game.settings.get("polyglot", "RuneRegex") ? /[a-zA-Z\d]/g : /\S/gu;
 		const characters = selectedFont.alphabeticOnly
 			? "abcdefghijklmnopqrstuvwxyz"

--- a/src/module/logic.js
+++ b/src/module/logic.js
@@ -160,7 +160,7 @@ export class Polyglot {
 		for (const message of messages) {
 			if (
 				message.style === CONST.CHAT_MESSAGE_STYLES.IC
-				|| (this._isMessageTypeOOC(message.style) && message.getFlag("polyglot", "language"))
+				|| (message.style === CONST.CHAT_MESSAGE_STYLES.OOC && message.getFlag("polyglot", "language"))
 			) {
 				ui.chat.updateMessage(message);
 			}
@@ -597,15 +597,6 @@ export class Polyglot {
 		return /@|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)$/gi.test(
 			messageContent,
 		);
-	}
-
-	/**
-	 * Checks if a message is Out Of Character.
-	 * @param {Number} type
-	 * @returns {Boolean}
-	 */
-	_isMessageTypeOOC(type) {
-		return [CONST.CHAT_MESSAGE_STYLES.OOC, CONST.CHAT_MESSAGE_STYLES.WHISPER].includes(type);
 	}
 
 	_isOmniglot(lang) {

--- a/src/module/logic.js
+++ b/src/module/logic.js
@@ -50,7 +50,7 @@ export class Polyglot {
 						.reverse()
 						.find((m) => m.content === message);
 					// Message was sent in-character (no /ooc or /emote)
-					if (gameMessages?.type === CONST.CHAT_MESSAGE_TYPES.IC) {
+					if (gameMessages?.type === CONST.CHAT_MESSAGE_STYLES.IC) {
 						lang = gameMessages.getFlag("polyglot", "language") || "";
 						randomId = gameMessages.id;
 					}
@@ -159,8 +159,8 @@ export class Polyglot {
 			.map((m) => game.messages.get(m.dataset.messageId));
 		for (const message of messages) {
 			if (
-				message.type === CONST.CHAT_MESSAGE_TYPES.IC
-				|| (this._isMessageTypeOOC(message.type) && message.getFlag("polyglot", "language"))
+				message.style === CONST.CHAT_MESSAGE_STYLES.IC
+				|| (this._isMessageTypeOOC(message.style) && message.getFlag("polyglot", "language"))
 			) {
 				ui.chat.updateMessage(message);
 			}
@@ -605,7 +605,7 @@ export class Polyglot {
 	 * @returns {Boolean}
 	 */
 	_isMessageTypeOOC(type) {
-		return [CONST.CHAT_MESSAGE_TYPES.OOC, CONST.CHAT_MESSAGE_TYPES.WHISPER].includes(type);
+		return [CONST.CHAT_MESSAGE_STYLES.OOC, CONST.CHAT_MESSAGE_STYLES.WHISPER].includes(type);
 	}
 
 	_isOmniglot(lang) {


### PR DESCRIPTION
`message.type` has been renamed `message.style`, and with it the `CHAT_MESSAGE_TYPES` constant to `CHAT_MESSAGE_STYLES`.

I also found that `message` seemed to be correct (rather than `data`) in a web debugger for preCreateChatMessage.

Warning: this exact commit is untested. I tested these changes by applying them to the built/bundled polyglot.js (as downloaded and installed by FoundryVTT). I tried to be very careful about ensuring I was making the same changes.