### PR TITLE
pf1: add languages from items to known actor languages

### DIFF
--- a/src/module/providers/pf1.js
+++ b/src/module/providers/pf1.js
@@ -197,7 +197,7 @@ export default class pf1LanguageProvider extends LanguageProvider {
 		let knownLanguages = new Set();
 		let literateLanguages = new Set();
 		if (actor.system?.traits?.languages) {
-			for (let lang of actor.system.traits.languages.value) {
+			for (let lang of actor.system.traits.languages.total) {
 				knownLanguages.add(lang);
 			}
 			if (actor.system.traits.languages.customTotal) {


### PR DESCRIPTION
Fixes #379 by using the `.total`, which contains the actor's inherent languages from `.value` as well as those granted by embedded items.