### PR TITLE
Fix literacy support to WFRP4e causing all pages to be scrambled

### DIFF
--- a/src/module/providers/wfrp4e.js
+++ b/src/module/providers/wfrp4e.js
@@ -110,7 +110,7 @@ export default class wfrp4eLanguageProvider extends LanguageProvider {
 		let knownLanguages = new Set();
 		let literateLanguages = new Set();
 		const readWrite = game.settings.get("polyglot", "ReadWrite");
-		const isLiterate = actor.items.find((item) => item.name === readWrite && item.type === "talent").length > 0;
+		const isLiterate = actor.items.find((item) => item.name === readWrite && item.type === "talent") != null;
 		let myRegex = new RegExp(`${game.settings.get("polyglot", "LanguageRegex")}\\s*\\((.+)\\)`, "i");
 		for (let item of actor.items) {
 			// adding only the descriptive language name, not "Language (XYZ)"


### PR DESCRIPTION
This fixes the bug introduced in 033663543206122aeba09ad2fe4a94ff2ecb8218 that causes all characters to be treated as illiterate regardless of whether they have the talent or not.