### PR TITLE
Fix #437 - Minor UI Label Issue with Native, Hyphenated System IDs

### DIFF
--- a/src/module/forms/LanguageSettings.js
+++ b/src/module/forms/LanguageSettings.js
@@ -1,3 +1,4 @@
+import { providerKeys } from "../providers/_shared.js";
 
 export class PolyglotLanguageSettings extends FormApplication {
 	/**
@@ -32,7 +33,7 @@ export class PolyglotLanguageSettings extends FormApplication {
 			const type = provider.id.substring(0, dotPosition);
 			const id = provider.id.substring(dotPosition + 1);
 			if (type === "native") {
-				let title = id === game.system.id ? game.system.title : id;
+				let title = id === game.system.id || id === providerKeys[game.system.id] ? game.system.title : id;
 				provider.selectTitle = (`${game.i18n.localize("POLYGLOT.LanguageProvider.choices.native")} ${title}`).trim();
 			} else {
 				const name = type === "module" ? game.modules.get(id).title : game.system.title;


### PR DESCRIPTION
Hello again! :wave: This is a fix for #437.

Hyphenated IDs are translated to camelCase for in-module use. This UI label fix expands an IF check for `game.system.id` to also check the module's list of camelCase'd system IDs in `providerKeys`.

##### From:
<img width="622" height="122" alt="Image" src="https://github.com/user-attachments/assets/40f3bd60-92e6-4da1-a3d4-be8d6a81af4b" />


##### To:
<img width="685" height="186" alt="image" src="https://github.com/user-attachments/assets/84dfc951-1c38-431f-9f7d-d122849596ee" />
